### PR TITLE
Potential fix for code scanning alert no. 1: Jinja2 templating with autoescape=False

### DIFF
--- a/send_email.py
+++ b/send_email.py
@@ -3,7 +3,7 @@ from date_time import date_time
 from sendgrid.helpers.mail import Mail,Content
 from sendgrid import SendGridAPIClient
 from dotenv import load_dotenv
-from jinja2 import Environment,FileSystemLoader
+from jinja2 import Environment, FileSystemLoader, select_autoescape
 
 # def formatted_datetime():
 #     # Get current date and time
@@ -39,7 +39,7 @@ def send_email_with_sendgrid(applications_list_final_with_expiry_dates: list[dic
             continue
         # Load the template file
         file_loader = FileSystemLoader('.')
-        env = Environment(loader=file_loader)
+        env = Environment(loader=file_loader, autoescape=select_autoescape(['html', 'xml']))
         template = env.get_template('email_template.html')
 
         # Render the template with dynamic data


### PR DESCRIPTION
Potential fix for [https://github.com/devwithkrishna/azure-app-registration-monitor/security/code-scanning/1](https://github.com/devwithkrishna/azure-app-registration-monitor/security/code-scanning/1)

To fix the problem, we need to ensure that the Jinja2 environment is created with `autoescape` enabled. This can be done by using the `select_autoescape` function, which will automatically enable escaping for HTML and XML templates. This change will ensure that any untrusted input is properly escaped, preventing XSS attacks.

- Modify the creation of the `Environment` object to include `autoescape=select_autoescape(['html', 'xml'])`.
- This change should be made in the `send_email_with_sendgrid` function where the `Environment` object is created.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
